### PR TITLE
Remove deprecated Digest::Digest

### DIFF
--- a/lib/aws/s3/authentication.rb
+++ b/lib/aws/s3/authentication.rb
@@ -68,7 +68,7 @@ module AWS
           memoized :canonical_string
 
           def encoded_canonical
-            digest   = OpenSSL::Digest::Digest.new('sha1')
+            digest   = OpenSSL::Digest.new('sha1')
             b64_hmac = [OpenSSL::HMAC.digest(digest, secret_access_key, canonical_string)].pack("m").strip
             url_encode? ? CGI.escape(b64_hmac) : b64_hmac
           end


### PR DESCRIPTION
Apparently our unicorn logs have a ton of `Digest::Digest is deprecated; use Digest` lines in them. I'm not entirely sure where they are all coming from yet, but given we only have 4 call sites in all of our gems, we might as well just get them all fixed up.  

/cc @technoweenie @mastahyeti @gregose 
