### PR TITLE
Fix AWS S3 Gem for Rails 4.1

### DIFF
--- a/lib/aws/s3/extensions.rb
+++ b/lib/aws/s3/extensions.rb
@@ -240,7 +240,7 @@ class Class # :nodoc:
     cattr_reader(*syms)
     cattr_writer(*syms)
   end
-end if Class.instance_methods(false).grep(/^cattr_(?:reader|writer|accessor)$/).empty?
+end if Class.instance_methods.grep(/^cattr_(?:reader|writer|accessor)$/).empty?
 
 module SelectiveAttributeProxy
   def self.included(klass)


### PR DESCRIPTION
In Rails 4.1 `cattr_` methods were moved to the module (see
`rails/rails@7dfbd91`).

This means that the methods that create the writers and readers will
fail when they get a "symbol" called `{:instance_writer => false}`.

So when the AWS S3 gem is loaded you see this when trying to run tests:

```
/gems/aws-s3-0.6.3/lib/aws/s3/extensions.rb:223: `@@{' is not allowed as
a class variable name
```

The change here was taken from an unmerged PR on the original fork
`marcel/aws#94`.

Longer term we should consider switching from this gem to either
Shopify's fork or to the AWS supported S3 gem. For now this will get
Rails 4.1 development moving along.

I tested this in Rails 4.1 and Rails 3.2 and it appears to be backwards
compatible. 

---

I'm not sure who to ping on this?

cc/ @github/platform-systems @github/rails-upgrades 